### PR TITLE
Add Spanning Labs to README jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Find a gig in the interoperability space!
 - [LayerZero](https://boards.greenhouse.io/layerzerolabs)
 - [Multichain](https://docs.multichain.org/getting-started/careers)
 - [Nomad](https://boards.greenhouse.io/nomad)
+- [Spanning Labs](https://www.spanninglabs.com/#careers)
 - [Wormhole](https://boards.greenhouse.io/wormhole)
 
 # Tools


### PR DESCRIPTION
This change adds a link to the Spanning Labs job board.

Company Website: https://www.spanninglabs.com/
Documentation: https://docs.spanning.network
Simple Demo: https://demo.spanning.network/

Please let me know if I've missed a step regarding OSS contributions.